### PR TITLE
转义单引号

### DIFF
--- a/lib/rest.js
+++ b/lib/rest.js
@@ -14,7 +14,7 @@ var encode = window.encodeURIComponent
 
 var addParam = function(url, params, placeholder) {
   var arr = Object.keys(params).map(function(key) {
-    return key + '=' + (placeholder ? '{' + key + '}' : encode(params[key]))
+    return key + '=' + (placeholder ? '{' + key + '}' : encode(params[key]).replace(/'/g, '%27'))
   }).join('&')
 
   if (!arr) {


### PR DESCRIPTION
windows.encodeURIComponent不转义单引号，但是浏览器地址栏转义，于是造成params[key]包含单引号时，rest用于计算mac的url和向服务端提交的url不同，mac验证失败